### PR TITLE
put blue box around transcript upload button so it is easier to find

### DIFF
--- a/app/views/applicants/academic_records/_record_fields.html.erb
+++ b/app/views/applicants/academic_records/_record_fields.html.erb
@@ -21,7 +21,7 @@
   <div class="inner">
     <%= f.label :transcript %>
     <p>Attach a PDF or image of your transcript.</p>
-    <%= f.file_field :transcript %>
+    <%= f.file_field :transcript, :class => 'btn btn-primary btn-ar' %>
     <%= content_tag :p, raw("Current attachment: #{link_to current_applicant.records.find_by_applicant_id(current_applicant).transcript_file_name, current_applicant.records.find_by_applicant_id(current_applicant).transcript.url}") unless f.object.new_record?  %>
   </div>
 


### PR DESCRIPTION
Students were emailing transcripts in. The file upload button is so small and different from the theme buttons it might be hard to see. Added blue box around the file upload group so it will be easier to find.